### PR TITLE
Unit testing

### DIFF
--- a/app/src/main/kotlin/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryImpl.kt
+++ b/app/src/main/kotlin/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryImpl.kt
@@ -21,10 +21,10 @@ internal class ArtistInfoRepositoryImpl(
                 try {
                     artistInfo = lastFMService.getArtistInfo(artistName)
                     artistInfo?.let {
-                        saveArtistInfoDB(artistName, artistInfo)
+                        saveArtistInfoDB(artistName, it)
                     }
                 } catch (ioException: Exception) {
-                    ioException.printStackTrace()
+                    artistInfo = null
                 }
             }
         }

--- a/app/src/main/kotlin/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelper.kt
+++ b/app/src/main/kotlin/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelper.kt
@@ -33,12 +33,13 @@ internal class HtmlHelperImpl: HtmlHelper {
         val startBoldLabel = "<b>"
         val finishBoldLabel = "</b>"
 
-        text.replace(singleQuote, space)
-        text.replace(lineBreakJson, lineBreakHTML)
-        text.replace((caseInsensitive + term).toRegex(),
+        var modifiedText = text.replace(singleQuote, space)
+        modifiedText = modifiedText.replace(lineBreakJson, lineBreakHTML)
+        modifiedText = modifiedText.replace((caseInsensitive + term).toRegex(),
             startBoldLabel + term.uppercase(Locale.getDefault()) + finishBoldLabel)
 
-        return text
+        return modifiedText
     }
+
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
@@ -43,7 +43,7 @@ class HomeControllerTest {
     @Test
     fun `on more details event should navigate to more details`() {
         every { homeView.uiState } returns HomeUiState(songId = "id")
-        val song: Song = mockk { every { artistName } returns "artist" }
+        val song: Song.SpotifySong = mockk { every { artistName } returns "artist" }
         every { homeModel.getSongById("id") } returns song
 
         onActionSubject.notify(HomeUiEvent.MoreDetails)

--- a/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/controller/HomeControllerTest.kt
@@ -43,7 +43,7 @@ class HomeControllerTest {
     @Test
     fun `on more details event should navigate to more details`() {
         every { homeView.uiState } returns HomeUiState(songId = "id")
-        val song: Song.SpotifySong = mockk { every { artistName } returns "artist" }
+        val song: Song = mockk { every { artistName } returns "artist" }
         every { homeModel.getSongById("id") } returns song
 
         onActionSubject.notify(HomeUiEvent.MoreDetails)

--- a/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
@@ -1,7 +1,7 @@
 package ayds.lisboa.songinfo.home.model.repository
 
-import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
-import ayds.lisboa.songinfo.home.model.entities.Song.EmptySong
+import ayds.lisboa.songinfo.home.model.entities.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.EmptySong
 import ayds.lisboa.songinfo.home.model.repository.external.spotify.SpotifyTrackService
 import ayds.lisboa.songinfo.home.model.repository.local.spotify.SpotifyLocalStorage
 import io.mockk.every
@@ -41,7 +41,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by term should return song and mark it as local`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns song
 
         val result = songRepository.getSongByTerm("term")
@@ -52,7 +52,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given non existing song by term should get the song and store it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns null
@@ -66,7 +66,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by different term should get the song and update it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns song

--- a/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/model/repository/SongRepositoryTest.kt
@@ -1,7 +1,7 @@
 package ayds.lisboa.songinfo.home.model.repository
 
-import ayds.lisboa.songinfo.home.model.entities.SpotifySong
-import ayds.lisboa.songinfo.home.model.entities.EmptySong
+import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.Song.EmptySong
 import ayds.lisboa.songinfo.home.model.repository.external.spotify.SpotifyTrackService
 import ayds.lisboa.songinfo.home.model.repository.local.spotify.SpotifyLocalStorage
 import io.mockk.every
@@ -41,7 +41,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by term should return song and mark it as local`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns song
 
         val result = songRepository.getSongByTerm("term")
@@ -52,7 +52,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given non existing song by term should get the song and store it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns null
@@ -66,7 +66,7 @@ class SongRepositoryTest {
 
     @Test
     fun `given existing song by different term should get the song and update it`() {
-        val song = SpotifySong("id", "name", "artist", "album", "date", "url", "image", false)
+        val song = SpotifySong("id", "name", "artist", "album", "date", "releaseDatePrecision","url", "image", false)
         every { spotifyLocalStorage.getSongByTerm("term") } returns null
         every { spotifyTrackService.getSong("term") } returns song
         every { spotifyLocalStorage.getSongById("id") } returns song

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -1,14 +1,15 @@
 package ayds.lisboa.songinfo.home.view
 
 import ayds.lisboa.songinfo.home.model.entities.Song
-import ayds.lisboa.songinfo.home.model.entities.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl() }
+    private val dateCalculatorFactory: DateCalculatorFactory= DateCalculatorFactoryImpl
+    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateCalculatorFactory) }
 
     @Test
     fun `given a local song it should return the description`() {
@@ -18,7 +19,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
-            "year",
+            "day",
             "url",
             "url",
             true,
@@ -30,7 +31,7 @@ class SongDescriptionHelperTest {
             "Song: Plush [*]\n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Year: 1992"
+                "Release date: 01/01/1992"
 
         assertEquals(expected, result)
     }
@@ -43,7 +44,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
-            "year",
+            "day",
             "url",
             "url",
             false,
@@ -55,7 +56,7 @@ class SongDescriptionHelperTest {
             "Song: Plush \n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Year: 1992"
+                "Release date: 01/01/1992"
 
         assertEquals(expected, result)
     }

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -1,15 +1,14 @@
 package ayds.lisboa.songinfo.home.view
 
 import ayds.lisboa.songinfo.home.model.entities.Song
-import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
+import ayds.lisboa.songinfo.home.model.entities.SpotifySong
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val dateCalculatorFactory: DateCalculatorFactory= DateCalculatorFactoryImpl
-    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateCalculatorFactory) }
+    private val songDescriptionHelper by lazy { SongDescriptionHelperImpl() }
 
     @Test
     fun `given a local song it should return the description`() {
@@ -19,7 +18,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
-            "day",
+            "year",
             "url",
             "url",
             true,
@@ -31,7 +30,7 @@ class SongDescriptionHelperTest {
             "Song: Plush [*]\n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Release date: 01/01/1992"
+                "Year: 1992"
 
         assertEquals(expected, result)
     }
@@ -44,7 +43,7 @@ class SongDescriptionHelperTest {
             "Stone Temple Pilots",
             "Core",
             "1992-01-01",
-            "day",
+            "year",
             "url",
             "url",
             false,
@@ -56,7 +55,7 @@ class SongDescriptionHelperTest {
             "Song: Plush \n" +
                 "Artist: Stone Temple Pilots\n" +
                 "Album: Core\n" +
-                "Release date: 01/01/1992"
+                "Year: 1992"
 
         assertEquals(expected, result)
     }

--- a/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/home/view/SongDescriptionHelperTest.kt
@@ -2,13 +2,15 @@ package ayds.lisboa.songinfo.home.view
 
 import ayds.lisboa.songinfo.home.model.entities.Song
 import ayds.lisboa.songinfo.home.model.entities.Song.SpotifySong
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SongDescriptionHelperTest {
 
-    private val dateCalculatorFactory: DateCalculatorFactory= DateCalculatorFactoryImpl
+    private val dateCalculator = mockk<DateCalculator>()
+    private val dateCalculatorFactory = mockk<DateCalculatorFactory>()
     private val songDescriptionHelper by lazy { SongDescriptionHelperImpl(dateCalculatorFactory) }
 
     @Test
@@ -24,6 +26,8 @@ class SongDescriptionHelperTest {
             "url",
             true,
         )
+        every { dateCalculatorFactory.get("1992-01-01", "day") } returns dateCalculator
+        every { dateCalculator.getDate() } returns "01/01/1992"
 
         val result = songDescriptionHelper.getSongDescriptionText(song)
 
@@ -49,6 +53,8 @@ class SongDescriptionHelperTest {
             "url",
             false,
         )
+        every { dateCalculatorFactory.get("1992-01-01", "day") } returns dateCalculator
+        every { dateCalculator.getDate() } returns "01/01/1992"
 
         val result = songDescriptionHelper.getSongDescriptionText(song)
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -24,7 +24,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given non existing artist should return empty artist info`(){
+    fun `given non existing artist should return emptyArtistInfo`(){
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
         every { lastFmService.getArtistInfo("artistName") } returns null
 
@@ -34,7 +34,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given existing artist from db should return artist info`(){
+    fun `given existing artist from db should return artistInfo`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url")
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns artistInfo
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -1,0 +1,9 @@
+package ayds.lisboa.songinfo.moredetails.data
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ArtistInfoRepositoryTest {
+
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -45,7 +45,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given existing artist from service should get the artist info and store it`(){
+    fun `given existing artist from service should get the artistInfo and store it`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url", false)
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
         every { lastFmService.getArtistInfo("artistName") } returns artistInfo
@@ -58,7 +58,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given service exception should return empty artist info`() {
+    fun `given service exception should return emptyArtistInfo`() {
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
         every { lastFmService.getArtistInfo("artistName") } throws mockk<Exception>()
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -36,7 +36,6 @@ internal class ArtistInfoRepositoryTest {
     @Test
     fun `given existing artist from db should return artist info`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url")
-
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns artistInfo
 
         val result = artistInfoRepository.getArtistInfo("artistName")
@@ -48,7 +47,6 @@ internal class ArtistInfoRepositoryTest {
     @Test
     fun `given existing artist from service should get the artist info and store it`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url", false)
-
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
         every { lastFmService.getArtistInfo("artistName") } returns artistInfo
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -1,9 +1,72 @@
 package ayds.lisboa.songinfo.moredetails.data
 
+import ayds.lisboa.songinfo.moredetails.data.external.LastFmService
+import ayds.lisboa.songinfo.moredetails.data.local.LastFmLocalStorage
+import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo
+import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo.LastFmArtistInfo
+import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistInfoRepository
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.lang.Exception
 
 internal class ArtistInfoRepositoryTest {
+
+    private val lastFmLocalStorage: LastFmLocalStorage = mockk(relaxUnitFun = true)
+    private val lastFmService: LastFmService = mockk(relaxUnitFun = true)
+
+    private val artistInfoRepository: ArtistInfoRepository by lazy {
+        ArtistInfoRepositoryImpl(lastFmLocalStorage, lastFmService)
+    }
+
+    @Test
+    fun `given non existing artist should return empty artist info`(){
+        every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
+        every { lastFmService.getArtistInfo("artistName") } returns null
+
+        val result = artistInfoRepository.getArtistInfo("artistName")
+
+        assertEquals(result, ArtistInfo.EmptyArtistInfo)
+    }
+
+    @Test
+    fun `given existing artist in db should return artist info`(){
+        val artistInfo = LastFmArtistInfo("bioContent", "url")
+
+        every { lastFmLocalStorage.getArtistInfo("artistName") } returns artistInfo
+
+        val result = artistInfoRepository.getArtistInfo("artistName")
+
+        assertEquals(artistInfo, result)
+        assertTrue(artistInfo.isLocallyStored)
+    }
+
+    @Test
+    fun `given non existing artist shou`(){
+        val artistInfo = LastFmArtistInfo("bioContent", "url", false)
+
+        every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
+        every { lastFmService.getArtistInfo("artistName") } returns artistInfo
+
+        val result = artistInfoRepository.getArtistInfo("artistName")
+
+        assertEquals(artistInfo, result)
+        assertFalse(artistInfo.isLocallyStored)
+        verify { lastFmLocalStorage.saveArtist("artistName", artistInfo) }
+    }
+
+    @Test
+    fun `given service exception should return empty song`() {
+        every { lastFmLocalStorage.getArtistInfo("artistName") } returns null
+        every { lastFmService.getArtistInfo("artistName") } throws mockk<Exception>()
+
+        val result = artistInfoRepository.getArtistInfo("artistName")
+
+        assertEquals(ArtistInfo.EmptyArtistInfo, result)
+    }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/data/ArtistInfoRepositoryTest.kt
@@ -34,7 +34,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given existing artist in db should return artist info`(){
+    fun `given existing artist from db should return artist info`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url")
 
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns artistInfo
@@ -46,7 +46,7 @@ internal class ArtistInfoRepositoryTest {
     }
 
     @Test
-    fun `given non existing artist in service should return artist info`(){
+    fun `given existing artist from service should get the artist info and store it`(){
         val artistInfo = LastFmArtistInfo("bioContent", "url", false)
 
         every { lastFmLocalStorage.getArtistInfo("artistName") } returns null

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -20,7 +20,7 @@ internal class ArtistInfoHelperTest {
             "url",
             false
         )
-        every { htmlHelper.getHtmlText(any(), any()) } returns "Formatted bio"
+        every { htmlHelper.getHtmlText("bioContent", "") } returns "Formatted bio"
         val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
         assertEquals("Formatted bio", result)
     }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -11,8 +11,24 @@ internal class ArtistInfoHelperTest {
     private val htmlHelper = mockk<HtmlHelper>()
     private val artistInfoHelper by lazy {ArtistInfoHelperImpl(htmlHelper)}
 
+
     @Test
-    fun `given an artist name and an artist info it should return the formatted text`() {
+    fun `given an artistName and a lastFMArtistInfo with not empty bio and locallyStored it should return the right formatted text`() {
+        val artistName = ""
+        val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
+            "bioContent",
+            "url",
+            true
+        )
+
+        every { htmlHelper.getHtmlText("bioContent", "") } returns "Formatted bio"
+        val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
+
+        assertEquals("[*]Formatted bio", result)
+    }
+
+    @Test
+    fun `given an artistName and a lastFMArtistInfo with not empty bio and not locallyStored it should return the right formatted text`() {
         val artistName = ""
         val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
             "bioContent",
@@ -27,8 +43,36 @@ internal class ArtistInfoHelperTest {
     }
 
     @Test
-    fun `given a non last fm artist info return not found`(){
+    fun `given an artistName and a lastFMArtistInfo with empty bio and locallyStored it should return the right formatted text`() {
         val artistName = ""
+        val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
+            "",
+            "url",
+            true
+        )
+
+        val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
+
+        assertEquals("[*]No Results", result)
+    }
+
+    @Test
+    fun `given an artistName and a lastFMArtistInfo with empty bio and not locallyStored it should return the right formatted text`() {
+        val artistName = ""
+        val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
+            "",
+            "url",
+            false
+        )
+
+        val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
+
+        assertEquals("No Results", result)
+    }
+
+    @Test
+    fun `given a non last fm artist info return not found`(){
+        val artistName=""
         val artistInfo: ArtistInfo = mockk()
 
         val result = artistInfoHelper.getArtistInfoText(artistName,artistInfo)
@@ -39,7 +83,7 @@ internal class ArtistInfoHelperTest {
 
     @Test
     fun `given an artist info it should return the url`() {
-        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url")
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url", false)
         val expectedUrl = "url"
 
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
@@ -49,9 +93,9 @@ internal class ArtistInfoHelperTest {
 
     @Test
     fun `given an artist info with invalid url it should return the no url found message`() {
-        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "")
-
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "", false)
         val expectedUrl = ""
+
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
 
         assertEquals(expectedUrl, result)
@@ -60,11 +104,12 @@ internal class ArtistInfoHelperTest {
     @Test
     fun `given an artist info that is not LastFmArtistInfo it should return the no url found message`() {
         val artistInfo = ArtistInfo.EmptyArtistInfo
-
         val expectedUrl = "Artist info url not found."
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
 
         assertEquals(expectedUrl, result)
     }
+
+
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -71,7 +71,7 @@ internal class ArtistInfoHelperTest {
     }
 
     @Test
-    fun `given a non last fm artist info return not found`(){
+    fun `given a non lastFMArtistInfo info return not found`(){
         val artistName=""
         val artistInfo: ArtistInfo = mockk()
 
@@ -82,7 +82,7 @@ internal class ArtistInfoHelperTest {
     }
 
     @Test
-    fun `given an artist info it should return the url`() {
+    fun `given a lastFMArtistInfo it should return the url`() {
         val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url", false)
         val expectedUrl = "url"
 
@@ -92,17 +92,7 @@ internal class ArtistInfoHelperTest {
     }
 
     @Test
-    fun `given an artist info with invalid url it should return the no url found message`() {
-        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "", false)
-        val expectedUrl = ""
-
-        val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
-
-        assertEquals(expectedUrl, result)
-    }
-
-    @Test
-    fun `given an artist info that is not LastFmArtistInfo it should return the no url found message`() {
+    fun `given a non lastFMArtistInfo it should return the no url found message`() {
         val artistInfo = ArtistInfo.EmptyArtistInfo
         val expectedUrl = "Artist info url not found."
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -1,0 +1,9 @@
+package ayds.lisboa.songinfo.moredetails.presentation
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class ArtistInfoHelperTest {
+
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -1,9 +1,68 @@
 package ayds.lisboa.songinfo.moredetails.presentation
 
+import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo
+import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 internal class ArtistInfoHelperTest {
+
+    private val htmlHelper = mockk<HtmlHelper>()
+    private val artistInfoHelper by lazy {ArtistInfoHelperImpl(htmlHelper)}
+
+    @Test
+    fun `given an artist name and an artist info it should return the formatted text`() {
+        // Arrange
+        val artistName = ""
+        val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
+            "bioContent",
+            "url",
+            false
+        )
+        every { htmlHelper.getHtmlText(any(), any()) } returns "Formatted bio"
+        val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
+        assertEquals("Formatted bio", result)
+    }
+
+    @Test
+    fun `given a non last fm artist info return not found`(){
+        val artistName=""
+        val artistInfo: ArtistInfo = mockk()
+        val result = artistInfoHelper.getArtistInfoText(artistName,artistInfo)
+        val expected = "Artist info not found."
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `given an artist info it should return the url`() {
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url", false)
+        val expectedUrl = "url"
+
+        val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
+
+        assertEquals(expectedUrl, result)
+    }
+
+    @Test
+    fun `given an artist info with invalid url it should return the no url found message`() {
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "", false)
+        val expectedUrl = ""
+
+        val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
+
+        assertEquals(expectedUrl, result)
+    }
+
+    @Test
+    fun `given an artist info that is not LastFmArtistInfo it should return the no url found message`() {
+        val artistInfo = ArtistInfo.EmptyArtistInfo
+        val expectedUrl = "Artist info url not found."
+        val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
+
+        assertEquals(expectedUrl, result)
+    }
+
+
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/ArtistInfoHelperTest.kt
@@ -13,30 +13,33 @@ internal class ArtistInfoHelperTest {
 
     @Test
     fun `given an artist name and an artist info it should return the formatted text`() {
-        // Arrange
         val artistName = ""
         val artistInfo: ArtistInfo = ArtistInfo.LastFmArtistInfo(
             "bioContent",
             "url",
             false
         )
+
         every { htmlHelper.getHtmlText("bioContent", "") } returns "Formatted bio"
         val result = artistInfoHelper.getArtistInfoText(artistName, artistInfo)
+
         assertEquals("Formatted bio", result)
     }
 
     @Test
     fun `given a non last fm artist info return not found`(){
-        val artistName=""
+        val artistName = ""
         val artistInfo: ArtistInfo = mockk()
+
         val result = artistInfoHelper.getArtistInfoText(artistName,artistInfo)
         val expected = "Artist info not found."
+
         assertEquals(expected, result)
     }
 
     @Test
     fun `given an artist info it should return the url`() {
-        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url", false)
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "url")
         val expectedUrl = "url"
 
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
@@ -46,9 +49,9 @@ internal class ArtistInfoHelperTest {
 
     @Test
     fun `given an artist info with invalid url it should return the no url found message`() {
-        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "", false)
-        val expectedUrl = ""
+        val artistInfo = ArtistInfo.LastFmArtistInfo("bioContent", "")
 
+        val expectedUrl = ""
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
 
         assertEquals(expectedUrl, result)
@@ -57,12 +60,11 @@ internal class ArtistInfoHelperTest {
     @Test
     fun `given an artist info that is not LastFmArtistInfo it should return the no url found message`() {
         val artistInfo = ArtistInfo.EmptyArtistInfo
+
         val expectedUrl = "Artist info url not found."
         val result = artistInfoHelper.getArtistInfoUrl(artistInfo)
 
         assertEquals(expectedUrl, result)
     }
-
-
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
@@ -1,9 +1,23 @@
-package ayds.lisboa.songinfo.moredetails.presentation
-
-import io.mockk.mockk
+import ayds.lisboa.songinfo.moredetails.presentation.HtmlHelper
+import ayds.lisboa.songinfo.moredetails.presentation.HtmlHelperImpl
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class HtmlHelperTest {
+class HtmlHelperImplTest {
 
+    private val htmlHelper: HtmlHelper by lazy {
+        HtmlHelperImpl()
+    }
+    @Test
+    fun `getHtmlText should return the correct HTML text`() {
+
+        val text = "Esto es una frase de testing"
+        val term = "frase"
+
+        val expectedText = """<html><div width=400><font face="arial">Esto es una frase de testing</font></div></html>""".trimIndent()
+
+        val result = htmlHelper.getHtmlText(text, term)
+
+        assertEquals(expectedText, result)
+    }
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
@@ -7,12 +7,11 @@ internal class HtmlHelperTest {
 
     @Test
     fun `getHtmlText should return the correct HTML text`() {
-
         val htmlHelper: HtmlHelper = HtmlHelperImpl()
         val text = "Hello world Lisbon 3"
         val term = "world"
-        val expectedHtmlText = "<html><div width=400><font face=\"arial\">Hello <b>WORLD</b> Lisbon 3</font></div></html>"
 
+        val expectedHtmlText = "<html><div width=400><font face=\"arial\">Hello <b>WORLD</b> Lisbon 3</font></div></html>"
         val result = htmlHelper.getHtmlText(text, term)
 
         assertEquals(expectedHtmlText, result)

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
@@ -1,23 +1,20 @@
-import ayds.lisboa.songinfo.moredetails.presentation.HtmlHelper
-import ayds.lisboa.songinfo.moredetails.presentation.HtmlHelperImpl
+package ayds.lisboa.songinfo.moredetails.presentation
+
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class HtmlHelperImplTest {
 
-    private val htmlHelper: HtmlHelper by lazy {
-        HtmlHelperImpl()
-    }
     @Test
     fun `getHtmlText should return the correct HTML text`() {
 
-        val text = "Esto es una frase de testing"
-        val term = "frase"
-
-        val expectedText = """<html><div width=400><font face="arial">Esto es una frase de testing</font></div></html>""".trimIndent()
+        val htmlHelper: HtmlHelper = HtmlHelperImpl()
+        val text = "Hello world Lisbon 3"
+        val term = "world"
+        val expectedHtmlText = "<html><div width=400><font face=\"arial\">Hello <b>WORLD</b> Lisbon 3</font></div></html>"
 
         val result = htmlHelper.getHtmlText(text, term)
 
-        assertEquals(expectedText, result)
+        assertEquals(expectedHtmlText, result)
     }
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
@@ -1,0 +1,9 @@
+package ayds.lisboa.songinfo.moredetails.presentation
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class HtmlHelperTest {
+
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/HtmlHelperTest.kt
@@ -3,7 +3,7 @@ package ayds.lisboa.songinfo.moredetails.presentation
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class HtmlHelperImplTest {
+internal class HtmlHelperTest {
 
     @Test
     fun `getHtmlText should return the correct HTML text`() {

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -1,0 +1,9 @@
+package ayds.lisboa.songinfo.moredetails.presentation
+
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class OtherInfoPresenterTest {
+
+}

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -17,13 +17,14 @@ internal class OtherInfoPresenterTest {
         val artistInfo:ArtistInfo = mockk()
         val bio = ""
         val url = ""
-        every { artistInfoRepository.getArtistInfo("artist") } returns artistInfo
-        every { artistInfoHelper.getArtistInfoText("artist",artistInfo) } returns bio
-        every { artistInfoHelper.getArtistInfoUrl(artistInfo) } returns url
         val otherInfoUiStateTester: (OtherInfoUiState) -> Unit = mockk(relaxed = true)
         otherInfoPresenter.uiEventObservable.subscribe {
             otherInfoUiStateTester(it)
         }
+
+        every { artistInfoRepository.getArtistInfo("artist") } returns artistInfo
+        every { artistInfoHelper.getArtistInfoText("artist",artistInfo) } returns bio
+        every { artistInfoHelper.getArtistInfoUrl(artistInfo) } returns url
         val otherInfoUiState = OtherInfoUiState(
             artistInfoBioContent = bio,
             artistInfoUrl = url
@@ -31,7 +32,6 @@ internal class OtherInfoPresenterTest {
         otherInfoPresenter.fetch("artist")
 
         verify { otherInfoUiStateTester(otherInfoUiState) }
-
     }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -7,7 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
 
-class OtherInfoPresenterTest {
+internal class OtherInfoPresenterTest {
     private val artistInfoRepository: ArtistInfoRepository = mockk()
     private val artistInfoHelper: ArtistInfoHelper= mockk()
     private val otherInfoPresenter = OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper)

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -11,6 +11,7 @@ import ayds.observer.Observable
 import ayds.observer.Subject
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -19,17 +20,20 @@ import org.junit.Test
 class OtherInfoPresenterTest {
     private val moreDetailsInjector =MoreDetailsInjector
     private val otherInfoView: OtherInfoView = mockk()
-    private lateinit var otherInfoPresenter: OtherInfoPresenter
+    private val artistInfoRepository: ArtistInfoRepository = mockk(relaxUnitFun = true)
+    private val artistInfoHelper: ArtistInfoHelper= mockk(relaxUnitFun = true)
+
+    private val otherInfoPresenter = spyk(OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper))
+
 
     @Before
     fun setup() {
         moreDetailsInjector.init(otherInfoView)
-        otherInfoPresenter = moreDetailsInjector.getPresenter()
     }
 
     @Test
     fun `on fetch should notify view with uiState`() {
-
+        otherInfoPresenter.fetch("artist")
         verify { otherInfoPresenter.fetch("artist") }
     }
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -1,9 +1,36 @@
 package ayds.lisboa.songinfo.moredetails.presentation
 
+import ayds.lisboa.songinfo.home.controller.HomeControllerImpl
+import ayds.lisboa.songinfo.home.model.entities.Song
+import ayds.lisboa.songinfo.home.view.HomeUiEvent
+import ayds.lisboa.songinfo.home.view.HomeUiState
+import ayds.lisboa.songinfo.moredetails.dependencyinyector.MoreDetailsInjector
+import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo
+import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistInfoRepository
+import ayds.observer.Observable
+import ayds.observer.Subject
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
-internal class OtherInfoPresenterTest {
+class OtherInfoPresenterTest {
+    private val moreDetailsInjector =MoreDetailsInjector
+    private val otherInfoView: OtherInfoView = mockk()
+    private lateinit var otherInfoPresenter: OtherInfoPresenter
+
+    @Before
+    fun setup() {
+        moreDetailsInjector.init(otherInfoView)
+        otherInfoPresenter = moreDetailsInjector.getPresenter()
+    }
+
+    @Test
+    fun `on fetch should notify view with uiState`() {
+
+        verify { otherInfoPresenter.fetch("artist") }
+    }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -1,27 +1,21 @@
 package ayds.lisboa.songinfo.moredetails.presentation
 
-import ayds.lisboa.songinfo.home.controller.HomeControllerImpl
-import ayds.lisboa.songinfo.home.model.entities.Song
-import ayds.lisboa.songinfo.home.view.HomeUiEvent
-import ayds.lisboa.songinfo.home.view.HomeUiState
+
 import ayds.lisboa.songinfo.moredetails.dependencyinyector.MoreDetailsInjector
-import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo
 import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistInfoRepository
-import ayds.observer.Observable
-import ayds.observer.Subject
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
 class OtherInfoPresenterTest {
     private val moreDetailsInjector =MoreDetailsInjector
     private val otherInfoView: OtherInfoView = mockk()
-    private val artistInfoRepository: ArtistInfoRepository = mockk(relaxUnitFun = true)
-    private val artistInfoHelper: ArtistInfoHelper= mockk(relaxUnitFun = true)
+    private val artistInfoRepository: ArtistInfoRepository = mockk(relaxed = true)
+    private val artistInfoHelper: ArtistInfoHelper= mockk(relaxed = true)
+
+
 
     private val otherInfoPresenter = spyk(OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper))
 
@@ -34,7 +28,12 @@ class OtherInfoPresenterTest {
     @Test
     fun `on fetch should notify view with uiState`() {
         otherInfoPresenter.fetch("artist")
-        verify { otherInfoPresenter.fetch("artist") }
+
+        verify { val artist =
+            artistInfoRepository.getArtistInfo("artist")
+            artistInfoHelper.getArtistInfoText("artist",artist)
+            artistInfoHelper.getArtistInfoUrl(artist)}
+
     }
 
 }

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -3,6 +3,7 @@ package ayds.lisboa.songinfo.moredetails.presentation
 
 import ayds.lisboa.songinfo.moredetails.dependencyinyector.MoreDetailsInjector
 import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistInfoRepository
+import ayds.observer.Subject
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -14,7 +15,7 @@ class OtherInfoPresenterTest {
     private val otherInfoView: OtherInfoView = mockk()
     private val artistInfoRepository: ArtistInfoRepository = mockk(relaxed = true)
     private val artistInfoHelper: ArtistInfoHelper= mockk(relaxed = true)
-
+    private val onActionSubject = Subject<OtherInfoUiState>()
 
 
     private val otherInfoPresenter = spyk(OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper))
@@ -31,8 +32,10 @@ class OtherInfoPresenterTest {
 
         verify { val artist =
             artistInfoRepository.getArtistInfo("artist")
-            artistInfoHelper.getArtistInfoText("artist",artist)
-            artistInfoHelper.getArtistInfoUrl(artist)}
+            var otherInfoUiState = OtherInfoUiState(artistInfoHelper.getArtistInfoText("artist",artist),
+                    artistInfoHelper.getArtistInfoUrl(artist))
+           onActionSubject.notify(otherInfoUiState)
+        }
 
     }
 

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -13,7 +13,7 @@ internal class OtherInfoPresenterTest {
     private val otherInfoPresenter = OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper)
 
     @Test
-    fun `on fetch should notify view with uiState`() {
+    fun `on fetch should notify subscribers with otherInfoUiState`() {
         val artistInfo:ArtistInfo = mockk()
         val bio = ""
         val url = ""

--- a/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
+++ b/app/src/test/java/ayds/lisboa/songinfo/moredetails/presentation/OtherInfoPresenterTest.kt
@@ -1,41 +1,36 @@
 package ayds.lisboa.songinfo.moredetails.presentation
 
-
-import ayds.lisboa.songinfo.moredetails.dependencyinyector.MoreDetailsInjector
+import ayds.lisboa.songinfo.moredetails.domain.entities.ArtistInfo
 import ayds.lisboa.songinfo.moredetails.domain.repository.ArtistInfoRepository
-import ayds.observer.Subject
+import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
 import io.mockk.verify
-import org.junit.Before
 import org.junit.Test
 
 class OtherInfoPresenterTest {
-    private val moreDetailsInjector =MoreDetailsInjector
-    private val otherInfoView: OtherInfoView = mockk()
-    private val artistInfoRepository: ArtistInfoRepository = mockk(relaxed = true)
-    private val artistInfoHelper: ArtistInfoHelper= mockk(relaxed = true)
-    private val onActionSubject = Subject<OtherInfoUiState>()
-
-
-    private val otherInfoPresenter = spyk(OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper))
-
-
-    @Before
-    fun setup() {
-        moreDetailsInjector.init(otherInfoView)
-    }
+    private val artistInfoRepository: ArtistInfoRepository = mockk()
+    private val artistInfoHelper: ArtistInfoHelper= mockk()
+    private val otherInfoPresenter = OtherInfoPresenterImpl(artistInfoRepository,artistInfoHelper)
 
     @Test
     fun `on fetch should notify view with uiState`() {
+        val artistInfo:ArtistInfo = mockk()
+        val bio = ""
+        val url = ""
+        every { artistInfoRepository.getArtistInfo("artist") } returns artistInfo
+        every { artistInfoHelper.getArtistInfoText("artist",artistInfo) } returns bio
+        every { artistInfoHelper.getArtistInfoUrl(artistInfo) } returns url
+        val otherInfoUiStateTester: (OtherInfoUiState) -> Unit = mockk(relaxed = true)
+        otherInfoPresenter.uiEventObservable.subscribe {
+            otherInfoUiStateTester(it)
+        }
+        val otherInfoUiState = OtherInfoUiState(
+            artistInfoBioContent = bio,
+            artistInfoUrl = url
+        )
         otherInfoPresenter.fetch("artist")
 
-        verify { val artist =
-            artistInfoRepository.getArtistInfo("artist")
-            var otherInfoUiState = OtherInfoUiState(artistInfoHelper.getArtistInfoText("artist",artist),
-                    artistInfoHelper.getArtistInfoUrl(artist))
-           onActionSubject.notify(otherInfoUiState)
-        }
+        verify { otherInfoUiStateTester(otherInfoUiState) }
 
     }
 


### PR DESCRIPTION
En esta entrega se corrigen los test unitarios del paquete home:
- HomeControllerTest
- HomeModelTest
- SongRepositoryTest
- SongDescriptionHelperTest

Y se implementan los test unitarios del paquete moredetails:

**OtherInfoPresenterTest**
- Se testea que el metodo fetch notifique correctamente con un otherInfoUiState

**ArtistInfoHelperTest**
- Se testea el metodo getHtmlText:
  - Dado un artistName y un lastFMArtistInfo con bio no vacía y guardado localmente debería devolver el texto correctamente formateado
  - Dado un artistName y un lastFMArtistInfo con bio no vacía y no guardado localmente debería devolver el texto correctamente formateado
  - Dado un artistName y un lastFMArtistInfo con bio vacía y guardado localmente debería devolver el texto correctamente formateado
   - Dado un artistName y un lastFMArtistInfo con bio vacía y no guardado localmente debería devolver el texto correctamente formateado
  -  Dado un artistInfo debería devolver "Artist info not found"

- Se testea el metodo getHtmlUrl
  - Dado un lastFMArtistInfo debería devolver la url del mismo
  - Dado artistInfo debería devolver  "Artist info url not found."

**HtmlHelperTest**
- Se testea que el metodo getHtmlText devuelva correctamente el texto en formato  HTML.

**ArtistInfoRepositoryTest**
- Se testea el metodo getArtistInfo:
  - Dado un artista inexistente debería devolver un emptyArtistInfo
  - Dado un artista existente en la db debería devolver un artistInfo
  - Dado un artista existente por servicio debería devolver un artistInfo y guardarlo localmente
  - Dada una serviceException debería devolver un emptyArtistInfo

